### PR TITLE
Update Audi Q8: Correct model year start and add Wikipedia references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# Model make
+# Audi Q8
 
+This repository contains signal set configurations for the Audi Q8, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Audi Q8.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,5 +1,8 @@
+references:
+  - "https://en.wikipedia.org/wiki/Audi_Q8"
+
 generations:
   - name: "First Generation"
-    start_year: 2018
+    start_year: 2019
     end_year: null
     description: "The Audi Q8 is the brand's first coupe-SUV and serves as its flagship SUV model. Built on the MLB Evo platform shared with the Q7, it features a more aggressive, sporty design with a sloping roofline, frameless doors, and distinctive styling elements including an octagonal single-frame grille. Despite the coupe-like design, the Q8 offers generous interior space for five passengers. The interior features Audi's latest technology with a dual-touchscreen MMI system and virtual cockpit digital instruments. Engine options include V6 and V8 TFSI petrol and TDI diesel units with mild-hybrid technology standard. The performance lineup includes the SQ8 with a powerful V8 engine and the RS Q8, which shares its twin-turbo V8 with the Lamborghini Urus, producing 591 HP and temporarily holding the SUV lap record at the Nürburgring. The Q8 combines the practicality of an SUV with coupe-like styling and sporty driving dynamics, positioned as a more emotional alternative to the Q7."


### PR DESCRIPTION
- Fixed: Start year corrected from 2018 to 2019 per Wikipedia model_years
- Added: Wikipedia references to generations.yaml
- Updated: README.md with standard template

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
