### PR TITLE
Update Audi Q8 generations: correct production start year

### DIFF
--- a/generations.yaml
+++ b/generations.yaml
@@ -3,6 +3,6 @@ references:
 
 generations:
   - name: "First Generation"
-    start_year: 2019
+    start_year: 2018
     end_year: null
     description: "The Audi Q8 is the brand's first coupe-SUV and serves as its flagship SUV model. Built on the MLB Evo platform shared with the Q7, it features a more aggressive, sporty design with a sloping roofline, frameless doors, and distinctive styling elements including an octagonal single-frame grille. Despite the coupe-like design, the Q8 offers generous interior space for five passengers. The interior features Audi's latest technology with a dual-touchscreen MMI system and virtual cockpit digital instruments. Engine options include V6 and V8 TFSI petrol and TDI diesel units with mild-hybrid technology standard. The performance lineup includes the SQ8 with a powerful V8 engine and the RS Q8, which shares its twin-turbo V8 with the Lamborghini Urus, producing 591 HP and temporarily holding the SUV lap record at the Nürburgring. The Q8 combines the practicality of an SUV with coupe-like styling and sporty driving dynamics, positioned as a more emotional alternative to the Q7."


### PR DESCRIPTION
- Changed start_year from 2019 to 2018 (production began June 2018)
- First model year 2019 was based on vehicles arriving at dealers in August 2018
- Wikipedia source confirms June 2018 production start date
- No end year (production ongoing)

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
